### PR TITLE
RSpec 3 will call #supports_block_expectations?

### DIFF
--- a/lib/query_matchers/query_execution_matcher.rb
+++ b/lib/query_matchers/query_execution_matcher.rb
@@ -24,5 +24,9 @@ module QueryMatchers
     def negative_failure_message
       "expected block not to execute #{@expected} SQL queries, but did"
     end
+
+    def supports_block_expectations?
+      true
+    end
   end
 end


### PR DESCRIPTION
See http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#changes-to-the-matcher-protocol

> For matchers that are not intended to be used in block expectation expressions, you do not need to define it.

In the README, block expectations are used:

```rb
  it "works!" do
    expect { magician.magic! }.to execute_queries(43)
    expect { does_not_hit_the_database }.to execute_no_queries
    expect { hits_the_database_once }.to execute_one_query
  end
```

but not in this project’s own specs – so you won’t see the deprecation warnings by upgrading to RSpec 2.99 or 3.x…