### PR TITLE
Ignore schema queries

### DIFF
--- a/lib/query_matchers/query_counter.rb
+++ b/lib/query_matchers/query_counter.rb
@@ -28,7 +28,7 @@ module QueryMatchers
     end
 
     def count_query?(sql)
-      OPERATIONS.any? {|op| sql.start_with?(op) }
+      OPERATIONS.any? {|op| sql.lstrip.start_with?(op) }
     end
   end
 end

--- a/lib/query_matchers/query_counter.rb
+++ b/lib/query_matchers/query_counter.rb
@@ -1,6 +1,7 @@
 module QueryMatchers
   class QueryCounter
     OPERATIONS = %w(SELECT INSERT UPDATE DELETE)
+    RAILS5_INFORMATION_SCHEMA_REGEX = /^\s*SELECT.+FROM information_schema\./m
 
     def initialize
       @events = []
@@ -28,7 +29,11 @@ module QueryMatchers
     end
 
     def count_query?(sql)
-      OPERATIONS.any? {|op| sql.lstrip.start_with?(op) }
+      OPERATIONS.any? {|op| sql.lstrip.start_with?(op) } && !ignore_query?(sql)
+    end
+
+    def ignore_query?(sql)
+      sql.match?(RAILS5_INFORMATION_SCHEMA_REGEX)
     end
   end
 end

--- a/spec/query_counter_spec.rb
+++ b/spec/query_counter_spec.rb
@@ -42,6 +42,12 @@ describe QueryMatchers::QueryCounter do
     expect(counter.query_count).to eq(1)
   end
 
+  it "counts queries with a bit of whitespace" do
+    counter.execute!(sql_target("  SELECT FROM inventory"))
+
+    expect(counter.query_count).to eq(1)
+  end
+
   it "doesn't count any other type of query" do
     counter.execute!(sql_target("BREAKDANCE"))
 

--- a/spec/query_counter_spec.rb
+++ b/spec/query_counter_spec.rb
@@ -54,6 +54,19 @@ describe QueryMatchers::QueryCounter do
     expect(counter.query_count).to eq(0)
   end
 
+  it "ignores Rails 5's schema queries" do
+    counter.execute!(sql_target(<<-SQL))
+      SELECT column_name
+        FROM information_schema.key_column_usage
+       WHERE constraint_name = 'PRIMARY'
+         AND table_schema = DATABASE()
+         AND table_name = 'jokes'
+       ORDER BY ordinal_position
+    SQL
+
+    expect(counter.query_count).to eq(0)
+  end
+
   def sql_target(sql)
     proc { perform_sql(sql) }
   end


### PR DESCRIPTION
In Rails 5, the MySQL adapters finds schema information from the `information_schema` table which would be counted along with all other `SELECT` queries. Rails 4 used `SHOW TABLE` for schema info, which wouldn’t be counted at all by this gem.

With this PR, Rails 5’s MySQL schema queries are ignored.