### PR TITLE
This gem is compatible with Rails 6.0 and 6.1

### DIFF
--- a/query_matchers.gemspec
+++ b/query_matchers.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ["> 3.0", "< 6.0"]
+  spec.add_runtime_dependency "activesupport", ["> 3.0"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
It seems this part of the Rails API is pretty stable. Let's just remove the restriction on the ActiveSupport dependency.